### PR TITLE
[add] 透明化能力の発動制限 - キー入力を制限する変数を追加

### DIFF
--- a/Assets/Scripts/Transparent/Transparent.cs
+++ b/Assets/Scripts/Transparent/Transparent.cs
@@ -9,6 +9,8 @@ using DG.Tweening;
 /// </summary>
 public class Transparent : MonoBehaviour
 {
+    #region 変数
+
     [Header("透明化する対象")] [Tooltip("透明化する対象")]
     [SerializeField] private GameObject _target = default;
 
@@ -28,6 +30,18 @@ public class Transparent : MonoBehaviour
 
     private string _defaultLayerName = default;
 
+    [Header("キー入力ができるか")] [Tooltip("キー入力ができるか")]
+    [SerializeField] private bool _canInput = default;
+    
+    #endregion
+
+    /// <summary> キー入力ができるか </summary>
+    public bool CanInput
+    {
+        get => _canInput;
+        set => _canInput = value;
+    }
+    
     private void Start()
     {
         _renderers = _target.GetComponentsInChildren<Renderer>();
@@ -36,7 +50,7 @@ public class Transparent : MonoBehaviour
 
     private void Update()
     {
-        if (Input.GetButtonDown("Fire2"))
+        if (Input.GetButtonDown("Fire2") && CanInput)
         {
             OnClick();
         }


### PR DESCRIPTION
CanInputを偽にすると、右クリックしても能力が使えなくなります。
GetSetできるプロパティなので、外部から真偽の変更ができます。