### PR TITLE
[fix]　NPCの動きの修正

### DIFF
--- a/Assets/Scripts/NPC/FollowNPC.cs
+++ b/Assets/Scripts/NPC/FollowNPC.cs
@@ -37,11 +37,10 @@ public class FollowNPC : NPC
 
     public void Follow()
     {
-        _right = _targetNpcTransform.localPosition +
+        _right = _targetNpcTransform.position + 
                  _targetNpcTransform.TransformDirection(new Vector3(_distance, 0, 0));
-        _left = _targetNpcTransform.localPosition +
+        _left = _targetNpcTransform.position + 
                 _targetNpcTransform.TransformDirection(new Vector3(-_distance, 0, 0));
-
         var pos = transform.position;
         var distanceToRight = Vector3.Distance(pos, _right);
         var distanceToLeft = Vector3.Distance(pos, _left);

--- a/Assets/Scripts/NPC/NPC.cs
+++ b/Assets/Scripts/NPC/NPC.cs
@@ -218,7 +218,8 @@ public class NPC : MonoBehaviour
             {
                 Debug.Log("アニメーターが設定されていません");
             }
-
+            // よろけたアニメーションのままの移動をさせない
+            _navMeshAgent.isStopped = true;
             var dir = other.transform.position - transform.position;
             var pos = transform.position;
             transform.position = pos - dir.normalized; // otherとは逆方向に移動


### PR DESCRIPTION
プレイヤーにぶつかって、よろけた後の滑りをしないように、NavMeshAgentを停止した。
２人組のNPCの追尾がうまくいっていなかったため、追尾するposition取りを正した。