### PR TITLE
[fix]　NPCに関して

### DIFF
--- a/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_Patrol.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_Patrol.prefab
@@ -1,5 +1,36 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5880798655255768118
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3943181222277250375}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3943181222277250375
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5880798655255768118}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9164086294138098960}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &9164086292937077809
 GameObject:
   m_ObjectHideFlags: 0
@@ -101,6 +132,7 @@ Transform:
   m_Children:
   - {fileID: 9164086294096219675}
   - {fileID: 801197388983861357}
+  - {fileID: 3943181222277250375}
   m_Father: {fileID: 9164086292937077814}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -173,13 +205,13 @@ MonoBehaviour:
   _startPoint: {fileID: 9164086294096219674}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 5880798655255768118}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 9164086293080230045}
   _isWait: 0
   _standingWorkTime: 5
-  _standingWorkPositions:
-  - {fileID: 9164086293313034946}
+  _standingWorkPositions: []
 --- !u!95 &9164086293128146305
 Animator:
   serializedVersion: 5

--- a/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_Patrol_CardTouch.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_Patrol_CardTouch.prefab
@@ -36,6 +36,7 @@ Transform:
   m_Children:
   - {fileID: 8047819211123743819}
   - {fileID: 890871303812969858}
+  - {fileID: 7348977546067263843}
   m_Father: {fileID: 723625577117708934}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -108,6 +109,7 @@ MonoBehaviour:
   _startPoint: {fileID: 782634772411930220}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 4412614334648458541}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 723625577584994909}
@@ -306,6 +308,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 723625577584994908}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4412614334648458541
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7348977546067263843}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7348977546067263843
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4412614334648458541}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 723625575891999676}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &9219802351425222035
 PrefabInstance:

--- a/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_Patrol_Pair.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_Patrol_Pair.prefab
@@ -1,5 +1,67 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1844239178927109172
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6690301646334618307}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6690301646334618307
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1844239178927109172}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7059675340460204221}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4415516181728502850
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 884505908901140030}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &884505908901140030
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4415516181728502850}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7153006931475850639}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7003008209101417837
 GameObject:
   m_ObjectHideFlags: 0
@@ -66,6 +128,7 @@ Transform:
   m_Children:
   - {fileID: 314209774185047882}
   - {fileID: 2130905725696777369}
+  - {fileID: 6690301646334618307}
   m_Father: {fileID: 7059675342489110919}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -138,6 +201,7 @@ MonoBehaviour:
   _startPoint: {fileID: 7003008209101417837}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 1844239178927109172}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 7059675342152012124}
@@ -361,6 +425,7 @@ Transform:
   m_Children:
   - {fileID: 7153006929713058893}
   - {fileID: 2130905726629623180}
+  - {fileID: 884505908901140030}
   m_Father: {fileID: 7059675342489110919}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -454,6 +519,7 @@ MonoBehaviour:
   _startPoint: {fileID: 7153006929713058894}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 2
+  _rayOrigin: {fileID: 4415516181728502850}
   _targetNpcTransform: {fileID: 7059675340460204221}
   _distance: 0.7
   _speed: 1.8

--- a/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_SitDown_Talk.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_SitDown_Talk.prefab
@@ -164,6 +164,7 @@ Transform:
   m_Children:
   - {fileID: 8863532494493044114}
   - {fileID: 8531358726491631468}
+  - {fileID: 6169458567506107005}
   m_Father: {fileID: 4806519816321079465}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -236,6 +237,7 @@ MonoBehaviour:
   _startPoint: {fileID: 3466130858982087249}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 6720372948216974461}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 4806519816252440690}
@@ -281,6 +283,7 @@ MonoBehaviour:
   _startPoint: {fileID: 3466130858982087249}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 0}
 --- !u!1 &6245611461587823501
 GameObject:
   m_ObjectHideFlags: 0
@@ -311,6 +314,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4806519816252440691}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6720372948216974461
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6169458567506107005}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6169458567506107005
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6720372948216974461}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4806519817813324179}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &417473944881786749
 PrefabInstance:

--- a/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_Wait.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_Wait.prefab
@@ -1,5 +1,36 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3727181437254388441
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8023162796247440687}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8023162796247440687
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3727181437254388441}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6285706261131909697}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6285706260909576008
 GameObject:
   m_ObjectHideFlags: 0
@@ -66,6 +97,7 @@ Transform:
   m_Children:
   - {fileID: 6285706261510332428}
   - {fileID: 9047313363698225409}
+  - {fileID: 8023162796247440687}
   m_Father: {fileID: 6285706260909576009}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -122,6 +154,7 @@ MonoBehaviour:
   _startPoint: {fileID: 6285706261510332435}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 3727181437254388441}
 --- !u!95 &6285706261131909693
 Animator:
   serializedVersion: 5

--- a/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_Work_SitDown.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Man/MobNPC_Man_Work_SitDown.prefab
@@ -132,6 +132,7 @@ Transform:
   m_Children:
   - {fileID: 3080518351298098840}
   - {fileID: 936694569879009277}
+  - {fileID: 3560912211761721039}
   m_Father: {fileID: 1111292595055391598}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -204,6 +205,7 @@ MonoBehaviour:
   _startPoint: {fileID: 8675596183255648085}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 5505329037516404165}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 1111292594990066613}
@@ -262,6 +264,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1111292594990066612}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5505329037516404165
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3560912211761721039}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3560912211761721039
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5505329037516404165}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1111292595476011604}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8675596183255648085
 GameObject:

--- a/Assets/Prefabs/MobNPC/MobNPC_Man_Model/BgMD_Mori_DanseikenkyuinTaiki_0100 Variant.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Man_Model/BgMD_Mori_DanseikenkyuinTaiki_0100 Variant.prefab
@@ -70,7 +70,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: 139365d0dc4c6624593007c426acf91d,
         type: 3}
       propertyPath: m_Layer
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 5866666021909216657, guid: 139365d0dc4c6624593007c426acf91d, type: 3}

--- a/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_Patrol.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_Patrol.prefab
@@ -66,6 +66,7 @@ Transform:
   m_Children:
   - {fileID: 6703651233821679775}
   - {fileID: 7428927246162475172}
+  - {fileID: 6015748609040234701}
   m_Father: {fileID: 197477469896873577}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -138,6 +139,7 @@ MonoBehaviour:
   _startPoint: {fileID: 174298136252985987}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 9206278725978332538}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 197477469965733554}
@@ -293,6 +295,37 @@ Transform:
   m_Father: {fileID: 197477469965733555}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9206278725978332538
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6015748609040234701}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6015748609040234701
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9206278725978332538}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 197477468469886803}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &6521949186168031092
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -363,7 +396,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: b4587d9ea746b1147a8cbfe5c36c6b92,
         type: 3}
       propertyPath: m_Layer
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 5866666021909216657, guid: b4587d9ea746b1147a8cbfe5c36c6b92, type: 3}

--- a/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_Patrol_CardTouch.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_Patrol_CardTouch.prefab
@@ -67,6 +67,7 @@ Transform:
   m_Children:
   - {fileID: 345128284561777581}
   - {fileID: 4529173062432488342}
+  - {fileID: 5011096342418061671}
   m_Father: {fileID: 6593155133032027483}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -139,6 +140,7 @@ MonoBehaviour:
   _startPoint: {fileID: 6604872057822736817}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 7594018894359428976}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 6593155132827962752}
@@ -307,6 +309,37 @@ Transform:
   m_Father: {fileID: 6593155132378594401}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7594018894359428976
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5011096342418061671}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5011096342418061671
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7594018894359428976}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6593155132378594401}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &234359966579016774
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -377,7 +410,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: b4587d9ea746b1147a8cbfe5c36c6b92,
         type: 3}
       propertyPath: m_Layer
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 5866666021909216657, guid: b4587d9ea746b1147a8cbfe5c36c6b92, type: 3}

--- a/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_Patrol_Pair.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_Patrol_Pair.prefab
@@ -1,5 +1,67 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4352752454889224045
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4783345278773285707}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4783345278773285707
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4352752454889224045}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7129968473276594504}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6886971296069805402
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7450533876594834647}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7450533876594834647
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6886971296069805402}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6939809783433395322}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6939809783433395323
 GameObject:
   m_ObjectHideFlags: 0
@@ -35,6 +97,7 @@ Transform:
   m_Children:
   - {fileID: 4610168465739047862}
   - {fileID: 426264666862631821}
+  - {fileID: 7450533876594834647}
   m_Father: {fileID: 6939809783818032448}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -107,6 +170,7 @@ MonoBehaviour:
   _startPoint: {fileID: 6960743922906083754}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 6886971296069805402}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 6939809783887875483}
@@ -361,6 +425,7 @@ Transform:
   m_Children:
   - {fileID: 7311600530253035348}
   - {fileID: 7129968472625285258}
+  - {fileID: 4783345278773285707}
   m_Father: {fileID: 6939809783818032448}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -454,6 +519,7 @@ MonoBehaviour:
   _startPoint: {fileID: 7129968472625285257}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 2
+  _rayOrigin: {fileID: 4352752454889224045}
   _targetNpcTransform: {fileID: 6939809783433395322}
   _distance: 0.7
   _speed: 1.8
@@ -559,7 +625,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: b4587d9ea746b1147a8cbfe5c36c6b92,
         type: 3}
       propertyPath: m_Layer
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 5866666021909216657, guid: b4587d9ea746b1147a8cbfe5c36c6b92, type: 3}
@@ -660,7 +726,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: b4587d9ea746b1147a8cbfe5c36c6b92,
         type: 3}
       propertyPath: m_Layer
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 5866666021909216657, guid: b4587d9ea746b1147a8cbfe5c36c6b92, type: 3}

--- a/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_SitDown_Talk.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_SitDown_Talk.prefab
@@ -36,6 +36,7 @@ Transform:
   m_Children:
   - {fileID: 9090349098412002835}
   - {fileID: 1740496392195272158}
+  - {fileID: 5612295756999168577}
   m_Father: {fileID: 2419237457631885541}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -108,6 +109,7 @@ MonoBehaviour:
   _startPoint: {fileID: 5997880245433383453}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 4687468297718724956}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 2419237457831419966}
@@ -153,6 +155,7 @@ MonoBehaviour:
   _startPoint: {fileID: 5997880245433383453}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 0}
 --- !u!1 &2419237457631885540
 GameObject:
   m_ObjectHideFlags: 0
@@ -281,6 +284,37 @@ Transform:
   m_Father: {fileID: 2419237457831419967}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4687468297718724956
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5612295756999168577}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5612295756999168577
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4687468297718724956}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2419237456171061727}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5997880245433383453
 GameObject:
   m_ObjectHideFlags: 0
@@ -382,7 +416,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: b4587d9ea746b1147a8cbfe5c36c6b92,
         type: 3}
       propertyPath: m_Layer
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: b4587d9ea746b1147a8cbfe5c36c6b92,
         type: 3}

--- a/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_Wait.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_Wait.prefab
@@ -1,5 +1,36 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1778026457714069616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4254396956445279272}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4254396956445279272
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1778026457714069616}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7509667819042515505}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7509667818682765411
 GameObject:
   m_ObjectHideFlags: 0
@@ -65,6 +96,7 @@ Transform:
   m_Children:
   - {fileID: 7509667818682765436}
   - {fileID: 8051603162271149307}
+  - {fileID: 4254396956445279272}
   m_Father: {fileID: 7509667819290083129}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -121,6 +153,7 @@ MonoBehaviour:
   _startPoint: {fileID: 7509667818682765411}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 1778026457714069616}
 --- !u!95 &7509667819042515533
 Animator:
   serializedVersion: 5
@@ -244,7 +277,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: b4587d9ea746b1147a8cbfe5c36c6b92,
         type: 3}
       propertyPath: m_Layer
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b4587d9ea746b1147a8cbfe5c36c6b92, type: 3}

--- a/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_Work_SitDown.prefab
+++ b/Assets/Prefabs/MobNPC/MobNPC_Woman/MobNPC_Woman_Work_SitDown.prefab
@@ -31,6 +31,37 @@ Transform:
   m_Father: {fileID: 8870641030539982308}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4599334057021216664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5398765172158389306}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5398765172158389306
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4599334057021216664}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8870641030539982308}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7999017197562802170
 GameObject:
   m_ObjectHideFlags: 0
@@ -194,6 +225,7 @@ Transform:
   m_Children:
   - {fileID: 2643449108099082792}
   - {fileID: 6824906855525407016}
+  - {fileID: 5398765172158389306}
   m_Father: {fileID: 8870641030354296030}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -266,6 +298,7 @@ MonoBehaviour:
   _startPoint: {fileID: 870086972712528101}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 4599334057021216664}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 8870641030021383173}
@@ -364,7 +397,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: b4587d9ea746b1147a8cbfe5c36c6b92,
         type: 3}
       propertyPath: m_Layer
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 5866666021909216657, guid: b4587d9ea746b1147a8cbfe5c36c6b92, type: 3}

--- a/Assets/Prefabs/NPC/AssociateProfessor/MobNPC_Woman_AssociateProfessor_Death.prefab
+++ b/Assets/Prefabs/NPC/AssociateProfessor/MobNPC_Woman_AssociateProfessor_Death.prefab
@@ -67,8 +67,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 013f0c5b9b5be8945abae176889a88d6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _isDead: 0
-  _timeToPlay: 7
+  _isDead: 1
+  _timeToPlay: 5
   _latePlayStateName: Resurrection
 --- !u!1 &706471256823479154
 GameObject:

--- a/Assets/Prefabs/NPC/AssociateProfessor/MobNPC_Woman_Patrol_AssociateProfessor.prefab
+++ b/Assets/Prefabs/NPC/AssociateProfessor/MobNPC_Woman_Patrol_AssociateProfessor.prefab
@@ -1,5 +1,36 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2280060814938277088
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7383838105832421110}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7383838105832421110
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2280060814938277088}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3686631544365220360}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2824149616902805526
 GameObject:
   m_ObjectHideFlags: 0
@@ -92,8 +123,6 @@ Transform:
   m_Children:
   - {fileID: 3572514958425054978}
   - {fileID: 3572514959212761011}
-  - {fileID: 3572514958965054261}
-  - {fileID: 6109077757319010140}
   m_Father: {fileID: 3686631543107840818}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -253,37 +282,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3686631542770807784}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &3572514958965054262
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3572514958965054261}
-  m_Layer: 0
-  m_Name: Point (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 2974397684917235467, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3572514958965054261
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3572514958965054262}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.3999999, y: 0, z: -1.4}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3572514957681990832}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3572514959212761012
@@ -487,6 +485,7 @@ Transform:
   m_Children:
   - {fileID: 6236577927611663871}
   - {fileID: 6012379654308976414}
+  - {fileID: 7383838105832421110}
   m_Father: {fileID: 3686631543107840818}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -559,6 +558,7 @@ MonoBehaviour:
   _startPoint: {fileID: 3746753367665725400}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 2280060814938277088}
   _speed: 2
   _distance: 0.05
   _parentRoute: {fileID: 3686631542770807785}
@@ -609,7 +609,7 @@ MonoBehaviour:
   - {fileID: 3686631544365220363}
   - {fileID: 3572514958290667787}
   - {fileID: 3572514958290667786}
-  _deadPoint: {fileID: 6109077757319010141}
+  _deadPoint: {fileID: 0}
 --- !u!114 &3572514958290667787
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -627,6 +627,7 @@ MonoBehaviour:
   _startPoint: {fileID: 3746753367665725400}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 2280060814938277088}
   _speed: 2
   _distance: 0.05
   _parentRoute: {fileID: 3572514958397830991}
@@ -650,6 +651,7 @@ MonoBehaviour:
   _startPoint: {fileID: 3746753367665725400}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 2280060814938277088}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 3572514957681990833}
@@ -686,37 +688,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 3686631544365220360}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6109077757319010141
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6109077757319010140}
-  m_Layer: 0
-  m_Name: Point (3)
-  m_TagString: Untagged
-  m_Icon: {fileID: 2974397684917235467, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6109077757319010140
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6109077757319010141}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.46, y: 0, z: 4.18}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3572514957681990832}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &3447097037488082151
 PrefabInstance:

--- a/Assets/Prefabs/NPC/AssociateProfessor_Model/BgMD_Mori_ZyunkyozyuTaiki_0100 Variant.prefab
+++ b/Assets/Prefabs/NPC/AssociateProfessor_Model/BgMD_Mori_ZyunkyozyuTaiki_0100 Variant.prefab
@@ -65,12 +65,12 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: c1f7ba11e6acd134d849af9bc4a5583c,
         type: 3}
       propertyPath: m_Name
-      value: BgMD_Mori_ZyunkyozyuTaiki_0100
+      value: BgMD_Mori_ZyunkyozyuTaiki_0100 Variant
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: c1f7ba11e6acd134d849af9bc4a5583c,
         type: 3}
       propertyPath: m_Layer
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 5866666021909216657, guid: c1f7ba11e6acd134d849af9bc4a5583c, type: 3}

--- a/Assets/Prefabs/NPC/Professor/MobNPC_Woman_Patrol_Professor.prefab
+++ b/Assets/Prefabs/NPC/Professor/MobNPC_Woman_Patrol_Professor.prefab
@@ -1,5 +1,36 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5899791303875969351
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1293849882040118327}
+  m_Layer: 0
+  m_Name: RayOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1293849882040118327
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5899791303875969351}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7489000201558900217}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7301411104586424944
 GameObject:
   m_ObjectHideFlags: 0
@@ -616,6 +647,7 @@ Transform:
   m_Children:
   - {fileID: 4061109903601279541}
   - {fileID: 165238246170262030}
+  - {fileID: 1293849882040118327}
   m_Father: {fileID: 7489000201473873091}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -688,6 +720,7 @@ MonoBehaviour:
   _startPoint: {fileID: 7437951572504113193}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 5899791303875969351}
   _speed: 3
   _distance: 0.05
   _parentRoute: {fileID: 7489000201135721496}
@@ -759,6 +792,7 @@ MonoBehaviour:
   _startPoint: {fileID: 7437951572504113193}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 5899791303875969351}
   _speed: 3
   _distance: 0.05
   _parentRoute: {fileID: 7301411104738953406}
@@ -782,6 +816,7 @@ MonoBehaviour:
   _startPoint: {fileID: 7437951572504113193}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 5899791303875969351}
   _speed: 3
   _distance: 0.05
   _parentRoute: {fileID: 7301411105064821568}
@@ -805,6 +840,7 @@ MonoBehaviour:
   _startPoint: {fileID: 7437951572504113193}
   _direction: {x: 1, y: 0, z: 0.5}
   _raycastLength: 1.5
+  _rayOrigin: {fileID: 5899791303875969351}
   _speed: 1
   _distance: 0.05
   _parentRoute: {fileID: 7301411105483937817}
@@ -925,7 +961,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: b4587d9ea746b1147a8cbfe5c36c6b92,
         type: 3}
       propertyPath: m_Layer
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8416536936033435989, guid: b4587d9ea746b1147a8cbfe5c36c6b92,
         type: 3}

--- a/Assets/Scripts/NPC/AssociateProfessorDeadOrAlive.cs
+++ b/Assets/Scripts/NPC/AssociateProfessorDeadOrAlive.cs
@@ -2,8 +2,7 @@ using UnityEngine;
 /// <summary>
 /// 死亡モーションをする
 /// IsDeadが偽になると、立ち上がる
-/// ※倒れるまではIsDeadの真偽に関係なく実行される
-/// IsDeadの影響が出るのは、倒れてからになる
+/// 倒れてから残り時間10秒になる前までは、死亡フラグを偽にできる
 /// </summary>
 public class AssociateProfessorDeadOrAlive : DeadOrAliveBase
 {
@@ -11,9 +10,12 @@ public class AssociateProfessorDeadOrAlive : DeadOrAliveBase
     [SerializeField] private string _latePlayStateName = default;
     [Header("秒数カウント開始"), Tooltip("秒数カウント開始")]
     private bool _isCount = default;
+    [Header("残り時間を持つクラス"), Tooltip("残り時間を持つクラス")]
+    protected CountDownTimer _countDownTimer = default;
     
     protected override void OnStart()
     {
+        _countDownTimer = FindObjectOfType<CountDownTimer>();
         _canPlay = true;
         _animator.Play("Unwell"); // 倒れるまでは共通
         _isCount = false;
@@ -21,14 +23,6 @@ public class AssociateProfessorDeadOrAlive : DeadOrAliveBase
     
     protected override void OnUpdate()
     {
-        if (!IsDead)
-        {
-            if (_canPlay)
-            {
-                _animator.SetTrigger("ElectricShock"); // AED
-                _canPlay = false;
-            }
-        }
 
         if (_animator.GetCurrentAnimatorStateInfo(0).IsName("Laying Seizure"))
         {
@@ -40,6 +34,18 @@ public class AssociateProfessorDeadOrAlive : DeadOrAliveBase
         {
             LatePlayAnim(_latePlayStateName);
             _isCount = false;
+        }
+        
+        // 残り時間が１０秒をきったら、フラグの干渉をできなくする
+        if(_countDownTimer.Timer <= 10f){return;}
+        
+        if (!IsDead)
+        {
+            if (_canPlay)
+            {
+                _animator.SetTrigger("ElectricShock"); // AED
+                _canPlay = false;
+            }
         }
     }
 }

--- a/Assets/Scripts/NPC/CardioPulmonaryArrest.cs
+++ b/Assets/Scripts/NPC/CardioPulmonaryArrest.cs
@@ -1,6 +1,6 @@
 /// <summary>
 /// 心配停止で死亡する准教授を生成する
-/// IsDeadフラグ次第で死亡する
+/// ここでは死亡フラグを変更できない
 /// 0:階段 1:踊り場 2:倒れる（生成）
 /// </summary>
 public class CardioPulmonaryArrest : VictimBase
@@ -29,13 +29,6 @@ public class CardioPulmonaryArrest : VictimBase
             }
             if (_character)
             {
-                // Todo: _isDeadフラグを適用する場所
-                ICanDead iCanDead = _character.transform.GetChild(0).GetComponent<ICanDead>();
-                if (iCanDead != _character.transform.GetChild(0).GetComponent<ICanDead>())
-                {
-                    return;
-                }
-                iCanDead.IsDead = _isDead;
                 gameObject.SetActive(false);
             }
         }

--- a/Assets/Scripts/NPC/NPC.cs
+++ b/Assets/Scripts/NPC/NPC.cs
@@ -40,6 +40,9 @@ public class NPC : MonoBehaviour
     [Header("レイの長さ")] [Tooltip("レイの長さ")]
     [SerializeField] private float _raycastLength = 2f;
 
+    [Header("レイを出す始点(壁越しさせない用)")] [Tooltip("レイを出す始点(壁越しさせない用)")]
+    [SerializeField] private GameObject _rayOrigin = default;
+
     #endregion
 
     #region"プロパティ"
@@ -182,7 +185,8 @@ public class NPC : MonoBehaviour
         if (other.CompareTag("Player") || other.CompareTag("RecordedPlayer"))
         {
             // 壁越しの回避をさせない
-            var origin = transform.position;
+            // var origin = transform.position;
+            var origin = _rayOrigin.transform.position;
             if(Physics.Raycast(origin, other.transform.position - origin, out RaycastHit hit))
             {
                 if(hit.collider.gameObject == other.gameObject)
@@ -224,7 +228,7 @@ public class NPC : MonoBehaviour
             var pos = transform.position;
             transform.position = pos - dir.normalized; // otherとは逆方向に移動
             _isTimer = true;
-            Debug.Log("よろける！！");
+            // Debug.Log("よろける！！");
         }
     }
 

--- a/Assets/Scripts/NPC/PatrolNPC.cs
+++ b/Assets/Scripts/NPC/PatrolNPC.cs
@@ -82,7 +82,6 @@ public class PatrolNPC : NPC
     protected override void OnStart()
     {
         _patrolState = new PatrolState(this);
-        NavMeshAgent.speed = _speed;
         _reachIndexNum = -1;
         _indexNum = 0; // 最初の目標地点
         // 経路を取得
@@ -105,6 +104,15 @@ public class PatrolNPC : NPC
         NpcStateMachine.ChangeState(_patrolState);
 
         _colliders = GetComponentsInChildren<Collider>();
+    }
+
+    /// <summary>
+    /// PatrolNPCが複数付いている場合、
+    /// 各PatrolNPCの速度を反映させるために、OnEnableで設定する必要がある
+    /// </summary>
+    private void OnEnable()
+    {
+        if(NavMeshAgent) NavMeshAgent.speed = _speed;
     }
 
     protected override void OnUpdate()

--- a/Assets/Scripts/NPC/TalkingNPC.cs
+++ b/Assets/Scripts/NPC/TalkingNPC.cs
@@ -56,7 +56,7 @@ public class TalkingState : StateBase
 
     public override void Update()
     {
-        Debug.Log("Update: Talking state");
+        // Debug.Log("Update: Talking state");
     }
 
     public override void Exit()


### PR DESCRIPTION
・NPCにレイを飛ばせるように、モデルのレイヤーはDefaultに直した
・余分なルート用の子オブジェクトを削除（准教授）
・名誉教授や准教授（タイムラインに合わせて行動する＝PatrolNPCが複数付いている）が、各巡回エリアで速度を変えられるように直した
・准教授：倒れてからAEDを使うため、倒れるまでは死亡フラグを偽にできないようにした
・准教授：仕様で残り時間が10秒以下になったら、AEDを使っても手遅れになるように制限をした