### PR TITLE
[add] 動きの記録、再現システムDemo

### DIFF
--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fcc37d15f6e7a58489050f191d9550c8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/RecordDemoScene.unity
+++ b/Assets/Scenes/RecordDemoScene.unity
@@ -1,0 +1,599 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1063573605
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1063573609}
+  - component: {fileID: 1063573608}
+  - component: {fileID: 1063573607}
+  - component: {fileID: 1063573606}
+  - component: {fileID: 1063573610}
+  - component: {fileID: 1063573611}
+  - component: {fileID: 1063573612}
+  m_Layer: 0
+  m_Name: Capsule
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!136 &1063573606
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063573605}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1063573607
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063573605}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1063573608
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063573605}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1063573609
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063573605}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1063573610
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063573605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a9fa8cbe6148f844b85c442a4985c1c4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _recordData: {fileID: 11400000, guid: 36a5ba2405d259a4fa9afc1e99e9ad36, type: 2}
+  _recordMode: 0
+--- !u!114 &1063573611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063573605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5a21a4ed0dafba44beb423a769ecf60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!54 &1063573612
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063573605}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 80
+  m_CollisionDetection: 0
+--- !u!1 &1523976542
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1523976545}
+  - component: {fileID: 1523976544}
+  - component: {fileID: 1523976543}
+  - component: {fileID: 1523976546}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1523976543
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523976542}
+  m_Enabled: 1
+--- !u!20 &1523976544
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523976542}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1523976545
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523976542}
+  m_LocalRotation: {x: 0.5, y: 0, z: 0, w: 0.8660254}
+  m_LocalPosition: {x: 0, y: 16.1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 60, y: 0, z: 0}
+--- !u!114 &1523976546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523976542}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+--- !u!1 &1614912072
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1614912074}
+  - component: {fileID: 1614912073}
+  - component: {fileID: 1614912075}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1614912073
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1614912072}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1614912074
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1614912072}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &1614912075
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1614912072}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 1
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+--- !u!1 &1649829475
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1649829479}
+  - component: {fileID: 1649829478}
+  - component: {fileID: 1649829477}
+  - component: {fileID: 1649829476}
+  m_Layer: 0
+  m_Name: Plane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!64 &1649829476
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649829475}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1649829477
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649829475}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1649829478
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649829475}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1649829479
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649829475}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/RecordDemoScene.unity.meta
+++ b/Assets/Scenes/RecordDemoScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3d870cebfe7646a4791a67a506fc3c90
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Record.meta
+++ b/Assets/Scripts/Record.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2de9c59c58e106646b9d3787c9c06cd5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Record/Demo.meta
+++ b/Assets/Scripts/Record/Demo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a11237af3fe58147b5bdc5be04acf1a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Record/Demo/FileCreator.cs
+++ b/Assets/Scripts/Record/Demo/FileCreator.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+public static class FileCreator
+{
+    /// <summary> 指定パスにファイルの生成を行う </summary>
+    /// <typeparam name="T"> 保存するデータの型 </typeparam>
+    /// <param name="path"> データテーブルのパス </param>
+    public static void CreateFile<T>(string path, T saveData) where T : ScriptableObject
+    {
+        //既にファイルが存在したら何もしない
+        if (File.Exists(path)) { Debug.Log("already exists"); return; }
+
+        T newAsset = ScriptableObject.CreateInstance<T>();
+
+        //初期値のコピー
+        foreach (var field in typeof(T).GetFields())
+        {
+            field.SetValue(newAsset, field.GetValue(saveData));
+        }
+        AssetDatabase.CreateAsset(newAsset, path);
+
+        AssetDatabase.SaveAssets();
+    }
+}

--- a/Assets/Scripts/Record/Demo/FileCreator.cs.meta
+++ b/Assets/Scripts/Record/Demo/FileCreator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 946ffcbd3ecf32e4bb4e24954876f320
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Record/Demo/MovementDemo.cs
+++ b/Assets/Scripts/Record/Demo/MovementDemo.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+
+public class MovementDemo : MonoBehaviour
+{
+    private Rigidbody _rb = default;
+
+    private void Start()
+    {
+        if (!gameObject.TryGetComponent(out _rb)) { _rb = gameObject.AddComponent<Rigidbody>(); }
+    }
+
+    private void Update()
+    {
+        var horizontal = Input.GetAxisRaw("Horizontal");
+        var vertical = Input.GetAxisRaw("Vertical");
+
+        _rb.velocity = new(horizontal, 0f, vertical);
+    }
+}

--- a/Assets/Scripts/Record/Demo/MovementDemo.cs.meta
+++ b/Assets/Scripts/Record/Demo/MovementDemo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5a21a4ed0dafba44beb423a769ecf60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Record/Demo/RecordDataDemo.cs
+++ b/Assets/Scripts/Record/Demo/RecordDataDemo.cs
@@ -1,0 +1,158 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace Recording
+{
+    namespace Demo
+    {
+        public enum RecordMode
+        {
+            /// <summary> 記録 </summary>
+            Record,
+            /// <summary> 再現 </summary>
+            Reproduce
+        }
+
+        public class RecordDataDemo : ScriptableObject
+        {
+            /// <summary> このデータが何番目のものか </summary>
+            public int ID = -1;
+            /// <summary> 最終的な位置 </summary>
+            public Vector3 Position;
+            /// <summary> 最終的な角度 </summary>
+            public Quaternion Rotation;
+            /// <summary> キャラクターがたどった経路 </summary>
+            public List<Vector3> WayPoints;
+
+            private int _targetIndex = 0;
+            private Vector3 _targetPos = default;
+            private Transform _target = default;
+
+            protected bool IsTargetPosChange => (_target.position - _targetPos).sqrMagnitude <= 1f;
+
+            public RecordDataDemo()
+            {
+                WayPoints = new();
+            }
+
+            #region Record
+            /// <summary> 記録開始 </summary>
+            public void RecordRun(Transform transform)
+            {
+                ID = 0;
+                Position = transform.position;
+                Rotation = transform.rotation;
+                WayPoints.Add(Position);
+
+                Debug.Log("Record Run");
+            }
+
+            /// <summary> 現在のデータを取得する </summary>
+            public RecordDataDemo GetCurrentRecord() => this;
+
+            /// <summary> データの更新 </summary>
+            public void Apply(Transform transform)
+            {
+                Position = transform.position;
+                Rotation = transform.rotation;
+                WayPoints.Add(Position);
+
+                Debug.Log("apply");
+            }
+
+            /// <summary> 最新データの保存 </summary>
+            public void Close(RecordDataDemo recordData)
+            {
+                FileCreator.CreateFile("Assets/Resources/RecordDataDemo.asset", recordData);
+                Debug.Log("closed");
+            }
+            #endregion
+
+            #region Reproduce
+            /// <summary> 再現対象の設定 </summary>
+            public void GetTransform(Transform target)
+            {
+                _target = target;
+                _targetPos = WayPoints[0];
+                _targetIndex = 0;
+            }
+
+            /// <summary> 保存されたデータの再現 </summary>
+            public void Reproduce()
+            {
+                if (IsTargetPosChange)
+                {
+                    if (_targetIndex + 1 >= WayPoints.Count) { return; }
+
+                    _targetIndex++;
+                    var nextPos = WayPoints[_targetIndex];
+                    _targetPos = nextPos;
+                }
+                _target.position = Vector3.Lerp(_target.position, _targetPos, Time.deltaTime);
+            }
+            #endregion
+        }
+
+        /// <summary> Animationパラメータの保存情報 </summary>
+        public class AnimationRecordDataDemo : ScriptableObject
+        {
+            public float Speed { get; private set; }
+            public Dictionary<string, bool> AnimationFlags { get; private set; }
+
+            /// <summary> 記録開始 </summary>
+            public void RecordRun()
+            {
+                Speed = 0f;
+
+                AnimationFlags = new()
+                {
+                    { "Collision", false },
+                    { "Crouch", false },
+                    { "Change", false },
+                    { "SelectAvility", false },
+                    { "UseAvility", false },
+                    { "GetItem", false },
+                    { "UseItem", false },
+                    { "UseKey", false },
+                    { "UseAED", false },
+                    { "Talk", false },
+                };
+                Debug.Log("Record Run");
+            }
+
+            /// <summary> 現在のデータを取得する </summary>
+            public AnimationRecordDataDemo GetCurrentRecord() => this;
+
+            public void Apply(float speed)
+            {
+                Speed = speed;
+                ApplyLog();
+            }
+
+            /// <summary> データの更新 </summary>
+            public void Apply(string param, bool flag)
+            {
+                try
+                {
+                    AnimationFlags[param] = flag;
+                    ApplyLog();
+                }
+                catch (KeyNotFoundException)
+                {
+                    Debug.LogError(
+                        $"KeyNotFound : 指定された名称のフラグ「{param}」が見つかりませんでした。" +
+                        $"名称が正しいか確認してください。");
+                }
+            }
+
+            private void ApplyLog() => Debug.Log("apply");
+
+            /// <summary> 最新データの保存 </summary>
+            public void Close(AnimationRecordDataDemo recordData)
+            {
+                FileCreator.CreateFile("Assets/Resources/AnimationRecordDataDemo.asset", recordData);
+                Debug.Log("closed");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Record/Demo/RecordDataDemo.cs.meta
+++ b/Assets/Scripts/Record/Demo/RecordDataDemo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ec8998b45f11b04aa926f06fe371e8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Record/Demo/Recorder.cs
+++ b/Assets/Scripts/Record/Demo/Recorder.cs
@@ -1,0 +1,44 @@
+﻿using UnityEngine;
+
+namespace Recording
+{
+    namespace Demo
+    {
+        public class Recorder : MonoBehaviour
+        {
+            [SerializeField]
+            private RecordDataDemo _recordData = default;
+            [Tooltip("記録対象の状態（新規に記録するか、記録を再現するか）")]
+            [SerializeField]
+            private RecordMode _recordMode = RecordMode.Record;
+
+            private void Start()
+            {
+                if (_recordData == null)
+                {
+                    _recordData = new();
+                    _recordMode = RecordMode.Record;
+                    _recordData.RecordRun(transform);
+                }
+                else
+                {
+                    _recordData.GetTransform(transform);
+                    _recordMode = RecordMode.Reproduce;
+                }
+            }
+
+            private void Update()
+            {
+                if (Input.GetKeyDown(KeyCode.Return) && _recordMode == RecordMode.Record) { _recordData.Apply(transform); }
+                else if (_recordMode == RecordMode.Reproduce) { _recordData.Reproduce(); }
+            }
+
+            private void OnDisable()
+            {
+                if (_recordMode == RecordMode.Reproduce) { return; }
+
+                _recordData.Close(_recordData);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Record/Demo/Recorder.cs.meta
+++ b/Assets/Scripts/Record/Demo/Recorder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9fa8cbe6148f844b85c442a4985c1c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
・「Assets/Scenes/RecordDemoScene.unity」にて実行確認済

==テスト内容==
1, 記録
・初期実行時は記録モード
・wasd移動を行い、Enterキー入力でその時の位置、角度を保存
・実行終了時に「Assets/Resources」に保存データのScriptableObjectファイルが新規生成される

2, 復元
・2周目以降、過去の動きを実行する場合は、「Assets/Resources」にあるScriptableObjectデータを対象オブジェクトのInspectorにある「Recorder.cs - RecordData」に割り当てる
・割り当てた状態で実行すると、保存された位置を巡回する

==今後の修正点==
・位置保存をオートにしていないため、修正する
　→手動テストのためにオート実装してない
・保存頻度の検討
　→毎フレームは重いため、ある程度考える
・複数データの保存
　→保存ファイル名の重複による2つ以上のデータ保存ができない状態になっているため、修正する